### PR TITLE
Update merchant to hold a list of its items

### DIFF
--- a/lib/invoice.rb
+++ b/lib/invoice.rb
@@ -6,24 +6,21 @@ class Invoice
               :merchant_id,
               :status,
               :created_at,
-              :updated_at
+              :updated_at,
+              :repository
 
-  def initialize(info)
+  def initialize(info, repository)
     @id = info[:id]
     @customer_id = info[:customer_id]
     @merchant_id = info[:merchant_id]
     @status = info[:status]
     @created_at = info[:created_at]
     @updated_at = info[:updated_at]
+    @repository = repository
   end
 
   def update(attributes)
     attributes[:status] && @status = attributes[:status]
-    @updated_at = convert_to_long_time
-  end
-
-  def convert_to_long_time
-    d = Time.now
-    Time.parse(d.strftime('%F %T.%L%L%L %z'))
+    @updated_at = Time.now
   end
 end

--- a/lib/invoice_repository.rb
+++ b/lib/invoice_repository.rb
@@ -3,8 +3,11 @@ require 'csv'
 require 'time'
 
 class InvoiceRepository
-  def initialize(filepath)
+  attr_reader :engine
+
+  def initialize(filepath, engine)
     @records = build_records(filepath)
+    @engine = engine
   end
 
   # :nocov:

--- a/lib/invoice_repository.rb
+++ b/lib/invoice_repository.rb
@@ -27,7 +27,7 @@ class InvoiceRepository
   end
 
   def invoice_from(attributes)
-    Invoice.new(attributes)
+    Invoice.new(attributes, self)
   end
 
   def find_by_id(id)
@@ -79,14 +79,9 @@ class InvoiceRepository
       customer_id: row[:customer_id].to_i,
       merchant_id: row[:merchant_id].to_i,
       status: row[:status].to_sym,
-      created_at: convert_to_long_time(row[:created_at]),
-      updated_at: convert_to_long_time(row[:updated_at])
+      created_at: Time.parse(row[:created_at]),
+      updated_at: Time.parse(row[:updated_at])
     }
-  end
-
-  def convert_to_long_time(date)
-    d = Time.parse(date)
-    Time.parse(d.strftime('%F %T.%L%L%L %z'))
   end
 
   def parameters

--- a/lib/merchant_repository.rb
+++ b/lib/merchant_repository.rb
@@ -61,7 +61,7 @@ class MerchantRepository
   end
 
   def items_by_merchant_id(id)
-    @engine.items.find_all_by_merchant_id(id)
+    @engine.items_by_merchant_id(id)
   end
 
   private

--- a/lib/sales_analyst.rb
+++ b/lib/sales_analyst.rb
@@ -1,7 +1,8 @@
 class SalesAnalyst
-  def initialize(merchant_repo, item_repo)
+  def initialize(merchant_repo, item_repo, invoice_repo)
     @merchant_repo = merchant_repo
     @item_repo = item_repo
+    @invoice_repo = invoice_repo
   end
 
   def average_items_per_merchant

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -4,14 +4,14 @@ require_relative 'invoice_repository'
 require_relative 'sales_analyst'
 
 class SalesEngine
-  attr_reader :merchants,
-              :items,
-              :invoices
+  attr_reader :merchant_repository,
+              :item_repository,
+              :invoice_repository
 
   def initialize(files)
-    @merchants = load_file(files[:merchants], MerchantRepository)
-    @items = load_file(files[:items], ItemRepository)
-    @invoices = load_file(files[:invoices], InvoiceRepository)
+    @merchant_repository = load_file(files[:merchants], MerchantRepository)
+    @item_repository = load_file(files[:items], ItemRepository)
+    @invoice_repository = load_file(files[:invoices], InvoiceRepository)
   end
 
   def self.from_csv(files)
@@ -23,6 +23,12 @@ class SalesEngine
   end
 
   def analyst
-    SalesAnalyst.new(@merchants, @items)
+    SalesAnalyst.new(@merchant_repository,
+                      @item_repository,
+                      @invoice_repository)
+  end
+
+  def items_by_merchant_id(merchant_id)
+    @item_repository.find_all_by_merchant_id(merchant_id)
   end
 end

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -24,8 +24,8 @@ class SalesEngine
 
   def analyst
     SalesAnalyst.new(@merchant_repository,
-                      @item_repository,
-                      @invoice_repository)
+                     @item_repository,
+                     @invoice_repository)
   end
 
   def items_by_merchant_id(merchant_id)

--- a/lib/sales_engine.rb
+++ b/lib/sales_engine.rb
@@ -4,14 +4,14 @@ require_relative 'invoice_repository'
 require_relative 'sales_analyst'
 
 class SalesEngine
-  attr_reader :merchant_repository,
-              :item_repository,
-              :invoice_repository
+  attr_reader :merchants,
+              :items,
+              :invoices
 
   def initialize(files)
-    @merchant_repository = load_file(files[:merchants], MerchantRepository)
-    @item_repository = load_file(files[:items], ItemRepository)
-    @invoice_repository = load_file(files[:invoices], InvoiceRepository)
+    @merchants = load_file(files[:merchants], MerchantRepository)
+    @items = load_file(files[:items], ItemRepository)
+    @invoices = load_file(files[:invoices], InvoiceRepository)
   end
 
   def self.from_csv(files)
@@ -23,12 +23,12 @@ class SalesEngine
   end
 
   def analyst
-    SalesAnalyst.new(@merchant_repository,
-                     @item_repository,
-                     @invoice_repository)
+    SalesAnalyst.new(@merchants,
+                     @items,
+                     @invoices)
   end
 
   def items_by_merchant_id(merchant_id)
-    @item_repository.find_all_by_merchant_id(merchant_id)
+    @items.find_all_by_merchant_id(merchant_id)
   end
 end

--- a/test/invoice_repository_test.rb
+++ b/test/invoice_repository_test.rb
@@ -5,7 +5,8 @@ require './lib/invoice_repository'
 class InvoiceRepositoryTest < Minitest::Test
   def setup
     filepath = './data/test_invoice.csv'
-    @repo = InvoiceRepository.new(filepath)
+    @engine = mock
+    @repo = InvoiceRepository.new(filepath, @engine)
   end
 
   def sorted_actual_ids(records)
@@ -25,6 +26,10 @@ class InvoiceRepositoryTest < Minitest::Test
 
   def test_it_exists
     assert_instance_of InvoiceRepository, @repo
+  end
+
+  def test_it_has_readable_attributes
+    assert_equal @engine, @repo.engine
   end
 
   def test_build_invoices

--- a/test/invoice_test.rb
+++ b/test/invoice_test.rb
@@ -3,13 +3,16 @@ require './lib/invoice'
 
 class InvoiceTest < Minitest::Test
   def setup
+    @repository = mock
     @invoice = Invoice.new(
-      id: 1,
-      customer_id: 2,
-      merchant_id: 3,
-      status: 'pending',
-      created_at: Time.new(2021, 1, 1, 8, 0, 0),
-      updated_at: Time.new(2021, 1, 1, 8, 0, 0)
+      {
+        id: 1,
+        customer_id: 2,
+        merchant_id: 3,
+        status: 'pending',
+        created_at: Time.new(2021, 1, 1, 8, 0, 0),
+        updated_at: Time.new(2021, 1, 1, 8, 0, 0)
+      }, @repository
     )
   end
 
@@ -24,6 +27,7 @@ class InvoiceTest < Minitest::Test
     assert_equal 'pending', @invoice.status
     assert_instance_of Time, @invoice.created_at
     assert_instance_of Time, @invoice.updated_at
+    assert_equal @repository, @invoice.repository
   end
 
   def test_can_update_certain_attributes

--- a/test/merchant_repository_test.rb
+++ b/test/merchant_repository_test.rb
@@ -11,17 +11,19 @@ class MerchantRepositoryTest < Minitest::Test
   end
 
   def create_item
-    Item.new(
-      {
-        id: 1,
-        name: 'Pencil',
-        description: 'You can use it to write things.',
-        unit_price: BigDecimal(1099, 4),
-        created_at: Time.new(2021, 1, 1, 8, 0, 0),
-        updated_at: Time.new(2021, 1, 1, 8, 0, 0),
-        merchant_id: 2
-      }, mock
-    )
+    Item.new(item_data, mock)
+  end
+
+  def item_data
+    {
+      id: 1,
+      name: 'Pencil',
+      description: 'You can use it to write things.',
+      unit_price: BigDecimal(1099, 4),
+      created_at: Time.new(2021, 1, 1, 8, 0, 0),
+      updated_at: Time.new(2021, 1, 1, 8, 0, 0),
+      merchant_id: 2
+    }
   end
 
   def sorted_actual_ids(merchants)

--- a/test/merchant_repository_test.rb
+++ b/test/merchant_repository_test.rb
@@ -10,6 +10,20 @@ class MerchantRepositoryTest < Minitest::Test
     @repo = MerchantRepository.new(filepath, @engine)
   end
 
+  def create_item
+    Item.new(
+      {
+        id: 1,
+        name: 'Pencil',
+        description: 'You can use it to write things.',
+        unit_price: BigDecimal(1099, 4),
+        created_at: Time.new(2021, 1, 1, 8, 0, 0),
+        updated_at: Time.new(2021, 1, 1, 8, 0, 0),
+        merchant_id: 2
+      }, mock
+    )
+  end
+
   def sorted_actual_ids(merchants)
     merchants.map(&:id).sort
   end
@@ -85,8 +99,13 @@ class MerchantRepositoryTest < Minitest::Test
   end
 
   def test_items_by_merchant_id
-    skip
-    @engine.stubs(:items).returns(ItemRepository)
-    assert_equal [], @repo.engine.items_by_merchant_id(1)
+    item = create_item
+    merchant_id = 1
+    @engine
+      .expects(:items_by_merchant_id)
+      .with(merchant_id)
+      .returns([item])
+
+    assert_equal [item], @repo.items_by_merchant_id(merchant_id)
   end
 end

--- a/test/merchant_test.rb
+++ b/test/merchant_test.rb
@@ -1,10 +1,27 @@
 require './test/test_helper'
+require 'bigdecimal'
 require './lib/merchant'
+require './lib/item'
 
 class MerchantTest < Minitest::Test
   def setup
     @repository = mock
     @merchant = Merchant.new({ id: 5, name: 'Turing School' }, @repository)
+    @sample_item = create_item
+  end
+
+  def create_item
+    Item.new(
+      {
+        id: 1,
+        name: 'Pencil',
+        description: 'You can use it to write things.',
+        unit_price: BigDecimal(1099, 4),
+        created_at: Time.new(2021, 1, 1, 8, 0, 0),
+        updated_at: Time.new(2021, 1, 1, 8, 0, 0),
+        merchant_id: 2
+      }, mock
+    )
   end
 
   def test_it_exists
@@ -21,5 +38,11 @@ class MerchantTest < Minitest::Test
     @merchant.update(name: 'Turing School Updated')
 
     assert_equal 'Turing School Updated', @merchant.name
+  end
+
+  def test_can_retrieve_items
+    @repository.stubs(:items_by_merchant_id).with(@merchant.id).returns([@sample_item])
+
+    assert_equal [@sample_item], @merchant.items
   end
 end

--- a/test/merchant_test.rb
+++ b/test/merchant_test.rb
@@ -7,7 +7,6 @@ class MerchantTest < Minitest::Test
   def setup
     @repository = mock
     @merchant = Merchant.new({ id: 5, name: 'Turing School' }, @repository)
-    @sample_item = create_item
   end
 
   def create_item
@@ -41,8 +40,9 @@ class MerchantTest < Minitest::Test
   end
 
   def test_can_retrieve_items
-    @repository.stubs(:items_by_merchant_id).with(@merchant.id).returns([@sample_item])
+    sample_item = create_item
+    @repository.stubs(:items_by_merchant_id).with(@merchant.id).returns([sample_item])
 
-    assert_equal [@sample_item], @merchant.items
+    assert_equal [sample_item], @merchant.items
   end
 end

--- a/test/merchant_test.rb
+++ b/test/merchant_test.rb
@@ -40,9 +40,12 @@ class MerchantTest < Minitest::Test
   end
 
   def test_can_retrieve_items
-    sample_item = create_item
-    @repository.stubs(:items_by_merchant_id).with(@merchant.id).returns([sample_item])
+    item = create_item
+    @repository
+      .expects(:items_by_merchant_id)
+      .with(@merchant.id)
+      .returns([item])
 
-    assert_equal [sample_item], @merchant.items
+    assert_equal [item], @merchant.items
   end
 end

--- a/test/merchant_test.rb
+++ b/test/merchant_test.rb
@@ -10,17 +10,19 @@ class MerchantTest < Minitest::Test
   end
 
   def create_item
-    Item.new(
-      {
-        id: 1,
-        name: 'Pencil',
-        description: 'You can use it to write things.',
-        unit_price: BigDecimal(1099, 4),
-        created_at: Time.new(2021, 1, 1, 8, 0, 0),
-        updated_at: Time.new(2021, 1, 1, 8, 0, 0),
-        merchant_id: 2
-      }, mock
-    )
+    Item.new(item_data, mock)
+  end
+
+  def item_data
+    {
+      id: 1,
+      name: 'Pencil',
+      description: 'You can use it to write things.',
+      unit_price: BigDecimal(1099, 4),
+      created_at: Time.new(2021, 1, 1, 8, 0, 0),
+      updated_at: Time.new(2021, 1, 1, 8, 0, 0),
+      merchant_id: 2
+    }
   end
 
   def test_it_exists

--- a/test/sales_analyst_test.rb
+++ b/test/sales_analyst_test.rb
@@ -6,7 +6,8 @@ class SalesAnalystTest < Minitest::Test
   def setup
     files = {
       items: './data/items.csv',
-      merchants: './data/merchants.csv'
+      merchants: './data/merchants.csv',
+      invoices: './data/invoices.csv'
     }
     sales_engine = SalesEngine.new(files)
     @analyst = sales_engine.analyst

--- a/test/sales_engine_test.rb
+++ b/test/sales_engine_test.rb
@@ -2,27 +2,32 @@ require './test/test_helper'
 require './lib/sales_engine'
 
 class SalesEngineTest < Minitest::Test
-  def test_it_exists
+  def setup
     files = {
       items: './data/items.csv',
       merchants: './data/merchants.csv',
       invoices: './data/invoices.csv'
     }
-    sales_engine = SalesEngine.new(files)
 
-    assert_instance_of SalesEngine, sales_engine
+    @engine = SalesEngine.from_csv(files)
   end
 
-  def test_from_csv
-    files = {
-      items: './data/items.csv',
-      merchants: './data/merchants.csv',
-      invoices: './data/invoices.csv'
-    }
+  def test_is_created_from_csv_files
+    assert_instance_of ItemRepository, @engine.item_repository
+    assert_instance_of MerchantRepository, @engine.merchant_repository
+    assert_instance_of InvoiceRepository, @engine.invoice_repository
+  end
 
-    sales_engine = SalesEngine.from_csv(files)
-    assert_instance_of ItemRepository, sales_engine.items
-    assert_instance_of MerchantRepository, sales_engine.merchants
-    assert_instance_of InvoiceRepository, sales_engine.invoices
+  def test_can_create_a_sales_analyst
+    assert_instance_of SalesAnalyst, @engine.analyst
+  end
+
+  def test_can_find_items_by_merchant_id
+    merchant_id = 12_334_159
+
+    result = @engine.items_by_merchant_id(merchant_id)
+
+    assert_instance_of Array, result
+    assert_equal true, result.all? { |object| object.is_a? Item }
   end
 end

--- a/test/sales_engine_test.rb
+++ b/test/sales_engine_test.rb
@@ -13,9 +13,9 @@ class SalesEngineTest < Minitest::Test
   end
 
   def test_is_created_from_csv_files
-    assert_instance_of ItemRepository, @engine.item_repository
-    assert_instance_of MerchantRepository, @engine.merchant_repository
-    assert_instance_of InvoiceRepository, @engine.invoice_repository
+    assert_instance_of ItemRepository, @engine.items
+    assert_instance_of MerchantRepository, @engine.merchants
+    assert_instance_of InvoiceRepository, @engine.invoices
   end
 
   def test_can_create_a_sales_analyst

--- a/test/sales_engine_test.rb
+++ b/test/sales_engine_test.rb
@@ -28,6 +28,6 @@ class SalesEngineTest < Minitest::Test
     result = @engine.items_by_merchant_id(merchant_id)
 
     assert_instance_of Array, result
-    assert_equal true, result.all? { |object| object.is_a? Item }
+    assert_equal true, (result.all? { |object| object.is_a? Item })
   end
 end


### PR DESCRIPTION
**What did you change?**
Continued work from @abreaux26 and @jbranham1 :
- Update tests which interract with higher-level objects
- Implement SalesEngine method for finding items by merchant id

**Next Steps**
- Work on SalesAnalyst
  - Refactor to use new items_by_merchant_id method from this branch
  - Get spec harness to run
  - Implement golden_items method
- Merge the branch.  Possible conflicts...
  - I had to update SalesAnalyst and SalesEngine to handle code @jbranham1 has been working on for Invoice stuff, which is still on her branch and not in main

**Known Issues**
- SalesEngine test is quite slow
- SalesAnalyst doesn't pass spec harness for Iteration 1. (See "Work on SalesAnalyst" from Next Steps)